### PR TITLE
Add WSL2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to Lab 0 of Autumn Term [Instruction Architectures and Compilers](http://intranet.ee.ic.ac.uk/electricalengineering/eecourses_t4/course_content.asp?c=ELEC50010&s=I2) (IAC).
 
-In this lab, you will install the tools needed for both the labs and coursework. The labs for this term can be run on both MacOS and Windows. Native Linux is not yet supported.
+In this lab, you will install the tools needed for both the labs and coursework. The labs for this term can be run on both macOS and Windows. Native Linux is not yet supported.
 
 At the end of the lab you will have installed the following tools:
 
@@ -40,10 +40,11 @@ At the end of the lab you will have installed the following tools:
 
 9) Follow the instructions in the [toolchain project](https://github.com/EIE2-IAC-Labs/Lab0-devtools/blob/main/autumn/workspace/toolchain) to test that your tools are functioning correctly. This folder is already downloaded and can be found in your VS Code workspace you just opened.
 
-### MacOS (Monterey or later)
+### macOS
 
-1) Install [VS Code](https://code.visualstudio.com/Download)
-2) Open a terminal and enter
+1) Make sure that your version of macOS is up-to-date. You must be running macOS Monterey or higher.
+2) Install [VS Code](https://code.visualstudio.com/Download)
+3) Open a terminal and enter
 
     ```bash
     bash <(curl -fsSL https://raw.githubusercontent.com/EIE2-IAC-Labs/Lab0-devtools/main/tools/install.sh)
@@ -52,8 +53,8 @@ At the end of the lab you will have installed the following tools:
     You may have to enter your password a few times while everything installs.
 
     Depending on your Internet connection, this may take up to 15 minutes.
-3) VS Code should automatically open after the previous step. If not, open the *workspace* at `~/Documents/iac/lab0-devtools/autumn/workspace/iac-autumn.code-workspace`; to do this open VS Code, and select "File->Open Workspace from File...", then navigate to the workspace file.
-4) Follow the instructions in the [toolchain project](https://github.com/EIE2-IAC-Labs/Lab0-devtools/blob/main/autumn/workspace/toolchain) to test that your tools are functioning correctly. This folder is already downloaded and can be found in your VS Code workspace you just opened.
+4) VS Code should automatically open after the previous step. If not, open the *workspace* at `~/Documents/iac/lab0-devtools/autumn/workspace/iac-autumn.code-workspace`; to do this open VS Code, and select "File->Open Workspace from File...", then navigate to the workspace file.
+5) Follow the instructions in the [toolchain project](https://github.com/EIE2-IAC-Labs/Lab0-devtools/blob/main/autumn/workspace/toolchain) to test that your tools are functioning correctly. This folder is already downloaded and can be found in your VS Code workspace you just opened.
 
 ## Behind the scenes
 

--- a/README.md
+++ b/README.md
@@ -19,27 +19,26 @@ At the end of the lab you will have installed the following tools:
 1) Make sure your version of Windows is up-to-date. You must be running Windows 10 (Build 19041 and higher) or Windows 11.
 2) Install [VS Code](https://code.visualstudio.com/Download). Once VS Code is installed, go [here](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) and install the Remote Development extension.
 3) Open Command Prompt as *Administrator* and enter `wsl --install` to enable Windows Subsystem for Linux (WSL). You will need to restart your machine after doing this.
-4) In Command Prompt, run `wsl --set-default-version 1` to use WSL version 1 instead of version 2. For this coursework, WSL 1 is required as WSL 2 does not support USB device access.
-5) Download Ubuntu 22.04 from the [Microsoft Store](https://www.microsoft.com/store/productId/9PN20MSR04DW). If you already have this downloaded, run `wsl --set-version Ubuntu-22.04 1` to make sure this runs under WSL 1.
-6) Download [Windows Terminal](https://aka.ms/terminal) for an improved terminal experience
-7) Open Windows Terminal and make a new Ubuntu 22.04 terminal
+4) Download Ubuntu 22.04 from the [Microsoft Store](https://www.microsoft.com/store/productId/9PN20MSR04DW).
+5) Download [Windows Terminal](https://aka.ms/terminal) for an improved terminal experience
+6) Open Windows Terminal and make a new Ubuntu 22.04 terminal
    ![Opening a new Windows Terminal tab for Ubuntu](./images/wsl_install.png)
-8) Inside the Ubuntu terminal, enter
+7) Inside the Ubuntu terminal, enter
 
     ```bash
     bash <(curl -fsSL https://raw.githubusercontent.com/EIE2-IAC-Labs/Lab0-devtools/main/tools/install.sh)
     ```
 
-    You may have to enter your password a few times while everything installs.
+    You may have to enter your password a few times while everything installs. Windows may also ask for administrator access.
 
     Depending on your Internet connection, this may take up to 15 minutes.
-9) VS Code should automatically open after the previous step. If not, open the *workspace* at `~/Documents/iac/lab0-devtools/autumn/workspace/iac-autumn.code-workspace`. To do this, open an Ubuntu 22.04 terminal and type `code`; doing this opens a [VS Code instance inside Ubuntu](https://code.visualstudio.com/docs/remote/wsl#_getting-started) rather than Windows. When VS Code opens, select "File->Open Workspace from File...", then navigate to the workspace file. You can also do this by typing the following command in an Ubuntu 22.04 terminal:
-   
+8) VS Code should automatically open after the previous step. If not, open the *workspace* at `~/Documents/iac/lab0-devtools/autumn/workspace/iac-autumn.code-workspace`. To do this, open an Ubuntu 22.04 terminal and type `code`; doing this opens a [VS Code instance inside Ubuntu](https://code.visualstudio.com/docs/remote/wsl#_getting-started) rather than Windows. When VS Code opens, select "File->Open Workspace from File...", then navigate to the workspace file. You can also do this by typing the following command in an Ubuntu 22.04 terminal:
+
    ```bash
    code ~/Documents/iac/lab0-devtools/autumn/workspace/iac-autumn.code-workspace
    ```
 
-10) Follow the instructions in the [toolchain project](https://github.com/EIE2-IAC-Labs/Lab0-devtools/blob/main/autumn/workspace/toolchain) to test that your tools are functioning correctly. This folder is already downloaded and can be found in your VS Code workspace you just opened.
+9) Follow the instructions in the [toolchain project](https://github.com/EIE2-IAC-Labs/Lab0-devtools/blob/main/autumn/workspace/toolchain) to test that your tools are functioning correctly. This folder is already downloaded and can be found in your VS Code workspace you just opened.
 
 ### Mac OS Monterey and Ubuntu 22.04
 
@@ -60,7 +59,7 @@ At the end of the lab you will have installed the following tools:
 
 The `bash <(curl -fsSL https://raw.githubusercontent.com/EIE2-IAC-Labs/Lab0-devtools/main/tools/install.sh)` first runs `curl`, which downloads the [install script](./tools/install.sh) from GitHub. The contents of this file are then redirected to the `bash` shell to be executed.
 
-The `install.sh` script installs a few common dependencies before detecting what Operating System you are running on. It then runs one of the OS specific scripts in the same folder. These  compile Verilator from source, as well as install the riscv-gnu-toolchain from pre-compiled binaries.
+The `install.sh` script installs a few common dependencies before detecting what Operating System you are running on. It then runs one of the OS specific scripts in the same folder. These  compile Verilator from source, as well as install the riscv-gnu-toolchain from pre-compiled binaries. The Windows-specific script installs the usbipd library on Windows for connecting USB devices to WSL.
 
 ## Something didn't work
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to Lab 0 of Autumn Term [Instruction Architectures and Compilers](http://intranet.ee.ic.ac.uk/electricalengineering/eecourses_t4/course_content.asp?c=ELEC50010&s=I2) (IAC).
 
-In this lab, you will install the tools needed for both the labs and coursework. The labs for this term can be run on both macOS and Windows. Native Linux is not yet supported.
+In this lab, you will install the tools needed for both the labs and coursework. The labs for this term can be run on both macOS and Windows. Native Linux is not supported.
 
 At the end of the lab you will have installed the following tools:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to Lab 0 of Autumn Term [Instruction Architectures and Compilers](http://intranet.ee.ic.ac.uk/electricalengineering/eecourses_t4/course_content.asp?c=ELEC50010&s=I2) (IAC).
 
-In this lab, you will install the tools needed for both the labs and coursework.
+In this lab, you will install the tools needed for both the labs and coursework. The labs for this term can be run on both MacOS and Windows. Native Linux is not yet supported.
 
 At the end of the lab you will have installed the following tools:
 
@@ -40,7 +40,7 @@ At the end of the lab you will have installed the following tools:
 
 9) Follow the instructions in the [toolchain project](https://github.com/EIE2-IAC-Labs/Lab0-devtools/blob/main/autumn/workspace/toolchain) to test that your tools are functioning correctly. This folder is already downloaded and can be found in your VS Code workspace you just opened.
 
-### Mac OS Monterey and Ubuntu 22.04
+### MacOS (Monterey or later)
 
 1) Install [VS Code](https://code.visualstudio.com/Download)
 2) Open a terminal and enter

--- a/tools/attach_usb.sh
+++ b/tools/attach_usb.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+# Regular expression for identifying Vbuddy in usbipd device info
+VBUDDY_REGEX="[0-9]-[0-9] .* USB-SERIAL CH340"
+
+# Get USB device info using Windows usbipd
+USB_INFO=$(powershell.exe /c usbipd list)
+
+if ! echo "$USB_INFO" | grep -q "$VBUDDY_REGEX"; then
+    echo "ERROR: Could not find Vbuddy. Is it plugged in?"
+    exit 1
+elif echo "$USB_INFO" | grep -q "$VBUDDY_REGEX .* Attached"; then
+    echo "Vbuddy already attached to WSL"
+    exit 0
+fi
+
+# Find the correct busid from the usbipd device info
+BUS_ID=$(echo "$USB_INFO" | grep "$VBUDDY_REGEX" | awk '{print $1}')
+
+# Share USB device with WSL if not already shared
+if echo "$USB_INFO" | grep -q "$VBUDDY_REGEX .* Not shared"; then
+    echo "Sharing Vbuddy USB port with WSL. This may require administrator access."
+    powershell.exe -Command "Start-Process 'usbipd.exe' -Verb runAs -ArgumentList 'bind --busid $BUS_ID'"
+fi
+
+# Attach USB device to WSL
+powershell.exe /c usbipd attach --wsl --busid $BUS_ID
+
+if powershell.exe /c usbipd list | grep -q "$VBUDDY_REGEX .* Attached"; then
+    echo "Vbuddy successfully attached to WSL"
+    exit 0
+else
+    echo "ERROR: Unknown error attaching Vbuddy to WSL"
+    exit 1
+fi

--- a/tools/attach_usb.sh
+++ b/tools/attach_usb.sh
@@ -21,7 +21,7 @@ BUS_ID=$(echo "$USB_INFO" | grep "$VBUDDY_REGEX" | awk '{print $1}')
 # Share USB device with WSL if not already shared
 if echo "$USB_INFO" | grep -q "$VBUDDY_REGEX .* Not shared"; then
     echo "Sharing Vbuddy USB port with WSL. This may require administrator access."
-    powershell.exe -Command "Start-Process 'usbipd.exe' -Verb runAs -ArgumentList 'bind --busid $BUS_ID'"
+    powershell.exe /c "Start-Process 'usbipd.exe' -Verb runAs -ArgumentList 'bind --busid $BUS_ID'"
 fi
 
 # Attach USB device to WSL

--- a/tools/ubuntu_wsl.sh
+++ b/tools/ubuntu_wsl.sh
@@ -24,3 +24,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "Running additional script from ${SCRIPT_DIR}"
 
 "${SCRIPT_DIR}/ubuntu.sh"
+
+echo "Installing usbipd library on Windows. This may require administrator access."
+powershell.exe /c winget install usbipd


### PR DESCRIPTION
- Update Windows installation README to use WSL2
- Add installation for Windows usbipd to WSL setup script
- Add script `attach_usb.sh` for connecting Vbuddy to WSL
- Update README to clarify that native Linux is not supported
- Other small clarity improvements to README